### PR TITLE
auto trigger: use lv_timer_set_repeat_count()

### DIFF
--- a/src/gfx_main.c
+++ b/src/gfx_main.c
@@ -46,6 +46,7 @@ static size_t chart_point_count = 0;
 static lv_coord_t chart_y_range = 0;
 
 static lv_timer_t * trigger_timer = NULL;
+static lv_timer_t * trigger_timer_turn_off = NULL;
 
 static void chart_reset(void);
 
@@ -114,12 +115,20 @@ static void auto_trigger_clear_timer(void)
     trigger_timer = NULL;
 }
 
+void auto_trigger_turn_off_callback(lv_timer_t * timer)
+{
+    (void)timer;
+    xlat_auto_trigger_turn_off_action();
+}
+
 void auto_trigger_callback(lv_timer_t * timer)
 {
     char label[20];
     size_t * count = timer->user_data;
 
     xlat_auto_trigger_action();
+    trigger_timer_turn_off = lv_timer_create(auto_trigger_turn_off_callback, AUTO_TRIGGER_PRESSED_PERIOD_MS, NULL);
+    lv_timer_set_repeat_count(trigger_timer_turn_off, 1);
 
     *count = (*count) - 1;
     if (*count) {

--- a/src/xlat.c
+++ b/src/xlat.c
@@ -603,7 +603,12 @@ enum xlat_mode xlat_get_mode(void)
 void xlat_auto_trigger_action(void)
 {
     HAL_GPIO_WritePin(ARDUINO_D11_GPIO_Port, ARDUINO_D11_Pin, auto_trigger_level_high ? GPIO_PIN_SET : GPIO_PIN_RESET);
-    HAL_Delay(20);
+//    HAL_Delay(40);
+//    HAL_GPIO_WritePin(ARDUINO_D11_GPIO_Port, ARDUINO_D11_Pin, auto_trigger_level_high ? GPIO_PIN_RESET : GPIO_PIN_SET);
+}
+
+void xlat_auto_trigger_turn_off_action(void)
+{
     HAL_GPIO_WritePin(ARDUINO_D11_GPIO_Port, ARDUINO_D11_Pin, auto_trigger_level_high ? GPIO_PIN_RESET : GPIO_PIN_SET);
 }
 

--- a/src/xlat.c
+++ b/src/xlat.c
@@ -602,9 +602,13 @@ enum xlat_mode xlat_get_mode(void)
 
 void xlat_auto_trigger_action(void)
 {
+    // random delay, such that we do not always perfectly align with USB timing
+    srand(xTaskGetTickCount());
+    int val = rand() & 0xFFF;
+    for (volatile int i = 0; i < val; i++) {
+        __NOP();
+    }
     HAL_GPIO_WritePin(ARDUINO_D11_GPIO_Port, ARDUINO_D11_Pin, auto_trigger_level_high ? GPIO_PIN_SET : GPIO_PIN_RESET);
-//    HAL_Delay(40);
-//    HAL_GPIO_WritePin(ARDUINO_D11_GPIO_Port, ARDUINO_D11_Pin, auto_trigger_level_high ? GPIO_PIN_RESET : GPIO_PIN_SET);
 }
 
 void xlat_auto_trigger_turn_off_action(void)

--- a/src/xlat.h
+++ b/src/xlat.h
@@ -23,6 +23,7 @@
 #include "src/usb/usbh_def.h"
 
 #define AUTO_TRIGGER_PERIOD_MS (150)
+#define AUTO_TRIGGER_PRESSED_PERIOD_MS (30)
 
 typedef struct hid_event {
     USBH_HandleTypeDef *phost;
@@ -86,6 +87,7 @@ hid_data_location_t * xlat_get_y_location(void);
 void xlat_clear_locations(void);
 
 void xlat_auto_trigger_action(void);
+void xlat_auto_trigger_turn_off_action(void);
 void xlat_auto_trigger_level_set(bool high);
 bool xlat_auto_trigger_level_is_high(void);
 


### PR DESCRIPTION
- add a random delay before triggering, such that it's not always aligned with USB timing (originating from the same clock source, eventually)