### PR TITLE
Fix TIM2 prescaler off-by-one

### DIFF
--- a/src/hardware_config.c
+++ b/src/hardware_config.c
@@ -354,7 +354,7 @@ static void MX_TIM2_Init(void)
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim2.Instance = TIM2;
-    htim2.Init.Prescaler = 100; // So we end up with 100 Mhz / 100 = 1 Mhz
+    htim2.Init.Prescaler = 100 - 1; // So we end up with 100 Mhz / 100 = 1 Mhz
     htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim2.Init.Period = 4294967295;
     htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;


### PR DESCRIPTION
If we want to prescale the timer by 100, ARR needs to be set to 99.