### PR TITLE
Fix for 0.8ms USB frames

### DIFF
--- a/drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
+++ b/drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
@@ -532,8 +532,11 @@ void HAL_HCD_IRQHandler(HCD_HandleTypeDef *hhcd)
         (void)USB_FlushTxFifo(USBx, 0x10U);
         (void)USB_FlushRxFifo(USBx);
 
-        /* Restore FS Clock */
-        (void)USB_InitFSLSPClkSel(hhcd->Instance, HCFG_48_MHZ);
+        if (hhcd->Init.phy_itface == USB_OTG_EMBEDDED_PHY)
+        {
+          /* Restore FS Clock */
+          (void)USB_InitFSLSPClkSel(hhcd->Instance, HCFG_48_MHZ);
+        }
 
         /* Handle Host Port Disconnect Interrupt */
 #if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)


### PR DESCRIPTION
This fixes an issue where after connecting a USB device to the HS port, disconnecting it and connecting it again, the USB frame time goes down to 0.8ms.

This is backported from stm32f7xx_hal_driver v1.3.1 release.