### PR TITLE
Let non-mouse/non-keyboard devices work

### DIFF
--- a/src/usb/usbh_hid.c
+++ b/src/usb/usbh_hid.c
@@ -70,7 +70,7 @@ static USBH_StatusTypeDef USBH_HID_InterfaceInit(USBH_HandleTypeDef *phost)
 
     // Broaden the search criteria to no specific protocol
     if (interface == 0xFFU) {
-        interface = USBH_FindInterface(phost, phost->pActiveClass->ClassCode, HID_BOOT_CODE, 0xFFU);
+        interface = USBH_FindInterface(phost, phost->pActiveClass->ClassCode, 0xFFU, 0xFFU);
     }
 
 #if 0


### PR DESCRIPTION
When searching for interfaces, when a mouse isn't found, accept any interface, even if the subclass isn't "Boot".

This lets us connect things like game controllers.