### PR TITLE
Improve report descriptor parsing

### DIFF
--- a/src/gfx_main.c
+++ b/src/gfx_main.c
@@ -303,15 +303,13 @@ static void new_theme_init_and_set(void)
 void gfx_set_byte_offsets_text(void)
 {
     char text[100];
-    hid_data_location_t * button = xlat_get_button_location();
-    hid_data_location_t * x = xlat_get_x_location();
-    hid_data_location_t * y = xlat_get_y_location();
+    uint16_t button_bits = xlat_get_button_bits();
+    uint16_t motion_bits = xlat_get_motion_bits();
 
-    if (button->found && x->found && y->found) {
-        sprintf(text, "Data: click@%d motion@%d,%d", button->byte_offset, x->byte_offset, y->byte_offset);
+    if (button_bits || motion_bits) {
+        sprintf(text, "Data (%u): %u button, %u motion bits", xlat_get_report_id(), button_bits, motion_bits);
     } else {
-        // offsets not found
-        sprintf(text, "Data: offsets not found");
+        sprintf(text, "Data: locations not found");
     }
 
     lv_checkbox_set_text(hid_offsets_label, text);

--- a/src/xlat.h
+++ b/src/xlat.h
@@ -30,13 +30,6 @@ typedef struct hid_event {
     uint32_t timestamp;
 } hid_event_t;
 
-typedef struct hid_data_location {
-    bool found;
-    size_t bit_index;
-    size_t bit_size;
-    size_t byte_offset;
-} hid_data_location_t;
-
 typedef enum latency_type {
     LATENCY_GPIO_TO_USB = 0,
     LATENCY_AUDIO_TO_USB,
@@ -72,18 +65,14 @@ uint32_t xlat_counter_1mhz_get(void);
 uint32_t xlat_get_last_usb_timestamp_us(void);
 uint32_t xlat_get_last_button_timestamp_us(void);
 
-
-void xlat_set_using_reportid(bool use_reportid);
-bool xlat_get_using_reportid(void);
-
 void xlat_parse_hid_descriptor(uint8_t *desc, size_t desc_size);
 
 void xlat_set_mode(enum xlat_mode mode);
 enum xlat_mode xlat_get_mode(void);
 
-hid_data_location_t * xlat_get_button_location(void);
-hid_data_location_t * xlat_get_x_location(void);
-hid_data_location_t * xlat_get_y_location(void);
+uint16_t xlat_get_button_bits(void);
+uint16_t xlat_get_motion_bits(void);
+uint16_t xlat_get_report_id(void);
 void xlat_clear_locations(void);
 
 void xlat_auto_trigger_action(void);


### PR DESCRIPTION
This lifts previously existing restictions on where the button and motion bits can reside within the input reports.

The data no longer has to start on byte boundary and doesn't have to be contiguous.

Should now work with any report ID.